### PR TITLE
define deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,10 @@
     "dropzone.js",
     "dropzone"
   ],
+  "dependencies": {
+    "angular": "~1.2.0",
+    "dropzone": "~3.10.2"
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Under some circumstances it may happen that build tool, i.e. grunt puts dropzone.js after angular-dropzone.js, resulting into undefined Dropzone.